### PR TITLE
Pushing proposed modifications to backend escapes, regex, and pipeline field mappings

### DIFF
--- a/sigma/backends/sentinelone_pq/sentinelone_pq.py
+++ b/sigma/backends/sentinelone_pq/sentinelone_pq.py
@@ -44,7 +44,7 @@ class SentinelOnePQBackend(TextQueryBackend):
     escape_char     : ClassVar[str] = "\\"
     wildcard_multi  : ClassVar[str] = "*"
     wildcard_single : ClassVar[str] = "*"
-    add_escaped     : ClassVar[str] = ""
+    add_escaped     : ClassVar[str] = "\\"
     filter_chars    : ClassVar[str] = ""
     bool_values     : ClassVar[Dict[bool, str]] = {
         True: "true",
@@ -57,7 +57,7 @@ class SentinelOnePQBackend(TextQueryBackend):
 
     re_expression : ClassVar[str] = "{field} matches \"{regex}\""
     re_escape_char : ClassVar[str] = "\\"
-    re_escape : ClassVar[Tuple[str]] = ()
+    re_escape : ClassVar[Tuple[str]] = ("\\(", "\\)", "\\[", "\\]", "\\{", "\\}", "\\.", "\\*", "\\+", "\\?", "\\|", "\\^", "\\$",)  # Characters to escape in regex
     re_escape_escape_char : bool = True
     re_flag_prefix : bool = False
 

--- a/sigma/pipelines/sentinelone_pq/sentinelone_pq.py
+++ b/sigma/pipelines/sentinelone_pq/sentinelone_pq.py
@@ -193,7 +193,7 @@ def sentinelonepq_pipeline() -> ProcessingPipeline:
         ProcessingItem(
             identifier="s1_pq_image_load_eventtype",
             transformation=AddConditionTransformation({
-                "event.type": "ModuleLoad"
+                "event.type": "Module Load"
             }),
             rule_conditions=[
                 LogsourceCondition(category="image_load")
@@ -213,7 +213,7 @@ def sentinelonepq_pipeline() -> ProcessingPipeline:
         ProcessingItem(
             identifier="s1_pq_registry_eventtype",
             transformation=AddConditionTransformation({
-                "event.category": "Registry"
+                "event.category": "registry"
             }),
             rule_condition_linking=any,
             rule_conditions=[
@@ -227,7 +227,7 @@ def sentinelonepq_pipeline() -> ProcessingPipeline:
         ProcessingItem(
             identifier="s1_pq_dns_objecttype",
             transformation=AddConditionTransformation({
-                "event.category":"DNS"
+                "event.category":"dns"
             }),
             rule_condition_linking=any,
             rule_conditions=[
@@ -239,7 +239,7 @@ def sentinelonepq_pipeline() -> ProcessingPipeline:
         ProcessingItem(
             identifier="s1_pq_network_objecttype",
             transformation=AddConditionTransformation({
-                "event.category": ["DNS","Url","IP"]
+                "event.category": ["dns","url","ip"]
             }),
             rule_conditions=[
                 LogsourceCondition(category="network_connection")

--- a/tests/test_backend_sentinelone_pq.py
+++ b/tests/test_backend_sentinelone_pq.py
@@ -125,7 +125,7 @@ def test_sentinelone_pq_cidr_query(sentinelone_pq_backend : SentinelOnePQBackend
                     DestinationIp|cidr: 192.168.0.0/16
                 condition: sel
         """)
-    ) == ['(event.category in ("DNS","Url","IP")) and dst.ip.address contains "192.168."']
+    ) == ['(event.category in ("dns","url","ip")) and dst.ip.address contains "192.168."']
 
 def test_sentinelone_pq_default_output(sentinelone_pq_backend : SentinelOnePQBackend):
     """Test for output format default."""

--- a/tests/test_pipelines_sentinelone_pq.py
+++ b/tests/test_pipelines_sentinelone_pq.py
@@ -121,7 +121,7 @@ def test_sentinelone_pq_image_load_mapping(sentinelone_pq_backend : SentinelOneP
                     ImageLoaded: foo bar
                 condition: sel
         """)
-    ) == ['event.type="ModuleLoad" and (src.process.image.path="valueA" and src.process.cmdline="invoke-mimikatz" and src.process.parent.image.path="valueB" and src.process.parent.cmdline="Get-Path" and module.sha1="asdfasdf" and module.md5="asdfasdfasdf" and module.path="foo bar")']
+    ) == ['event.type="Module Load" and (src.process.image.path="valueA" and src.process.cmdline="invoke-mimikatz" and src.process.parent.image.path="valueB" and src.process.parent.cmdline="Get-Path" and module.sha1="asdfasdf" and module.md5="asdfasdfasdf" and module.path="foo bar")']
 
 def test_sentinelone_pq_pipe_creation_mapping(sentinelone_pq_backend : SentinelOnePQBackend):
     assert sentinelone_pq_backend.convert(
@@ -160,7 +160,7 @@ def test_sentinelone_pq_registry_mapping(sentinelone_pq_backend : SentinelOnePQB
                     Details: bar foo
                 condition: sel
         """)
-    ) == ['event.category="Registry" and (src.process.image.path="valueA" and src.process.cmdline="invoke-mimikatz" and src.process.parent.image.path="valueB" and src.process.parent.cmdline="Get-Path" and registry.keyPath="foo bar" and registry.value="bar foo")']
+    ) == ['event.category="registry" and (src.process.image.path="valueA" and src.process.cmdline="invoke-mimikatz" and src.process.parent.image.path="valueB" and src.process.parent.cmdline="Get-Path" and registry.keyPath="foo bar" and registry.value="bar foo")']
 
 def test_sentinelone_pq_dns_mapping(sentinelone_pq_backend : SentinelOnePQBackend):
     assert sentinelone_pq_backend.convert(
@@ -182,7 +182,7 @@ def test_sentinelone_pq_dns_mapping(sentinelone_pq_backend : SentinelOnePQBacken
                     record_type: bar bar
                 condition: sel
         """)
-    ) == ['event.category="DNS" and (src.process.image.path="valueA" and src.process.cmdline="invoke-mimikatz" and src.process.parent.image.path="valueB" and src.process.parent.cmdline="Get-Path" and event.dns.request="foo bar" and event.dns.response="bar foo" and event.dns.request="foo foo" and event.dns.response="bar bar")']
+    ) == ['event.category="dns" and (src.process.image.path="valueA" and src.process.cmdline="invoke-mimikatz" and src.process.parent.image.path="valueB" and src.process.parent.cmdline="Get-Path" and event.dns.request="foo bar" and event.dns.response="bar foo" and event.dns.request="foo foo" and event.dns.response="bar bar")']
 
 def test_sentinelone_pq_network_mapping(sentinelone_pq_backend : SentinelOnePQBackend):
     assert sentinelone_pq_backend.convert(
@@ -211,7 +211,7 @@ def test_sentinelone_pq_network_mapping(sentinelone_pq_backend : SentinelOnePQBa
                     src_port: 8080
                 condition: sel
         """)
-    ) == ['(event.category in ("DNS","Url","IP")) and (src.process.image.path="valueA" and src.process.cmdline="invoke-mimikatz" and src.process.parent.image.path="valueB" and src.process.parent.cmdline="Get-Path" and (url.address="foo bar" or event.dns.request="foo bar") and dst.port.number=445 and dst.ip.address="0.0.0.0" and src.process.user="administrator" and src.ip.address="1.1.1.1" and src.port.number=135 and NetProtocolName="udp" and dst.ip.address="2.2.2.2" and src.ip.address="3.3.3.3" and dst.port.number=80 and src.port.number=8080)']
+    ) == ['(event.category in ("dns","url","ip")) and (src.process.image.path="valueA" and src.process.cmdline="invoke-mimikatz" and src.process.parent.image.path="valueB" and src.process.parent.cmdline="Get-Path" and (url.address="foo bar" or event.dns.request="foo bar") and dst.port.number=445 and dst.ip.address="0.0.0.0" and src.process.user="administrator" and src.ip.address="1.1.1.1" and src.port.number=135 and NetProtocolName="udp" and dst.ip.address="2.2.2.2" and src.ip.address="3.3.3.3" and dst.port.number=80 and src.port.number=8080)']
 
 def test_sentinelone_pq_unsupported_rule_type(sentinelone_pq_backend : SentinelOnePQBackend):
   with pytest.raises(ValueError):


### PR DESCRIPTION
I've made the following changes to the S1 PQ pySigma backend to accomodate for some changes that have been made to the S1QL over time.

* Modified field mappings for `event.type` & `event.category` fields in the pipeline to match what is presently utilized in S1
* Added escape character in the backend, which allows for searches on directories to return results
* Defined regex escape characters, allowing users to define special characters as literal characters if desired.
* Modified test cases to account for modified field mappings.